### PR TITLE
Feat: iOS ignore safearea top

### DIFF
--- a/app/ContentView.swift
+++ b/app/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
     var body: some View {
         ZStack {
             Webview(url: $url)
-                .edgesIgnoringSafeArea(.all)
+                .edgesIgnoringSafeArea(.top)
                 .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { notification in
                     if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                         self.keyboardHeight = keyboardFrame.height

--- a/app/WebVIew/Webview.swift
+++ b/app/WebVIew/Webview.swift
@@ -29,6 +29,7 @@ struct Webview: UIViewRepresentable {
         
         webview.insetsLayoutMarginsFromSafeArea = false
         webview.scrollView.contentInset = .zero
+        webview.scrollView.contentInsetAdjustmentBehavior = .never
         
         return webview
     }


### PR DESCRIPTION
## 📝 PR 유형

- [v] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->
React에서 Top에 제어하도록 하여 하단은 SafeArea 고정으로 하고 Top만 무시하도록 수정

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- SafeArea Top만 무시하도록 수정

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
